### PR TITLE
Optimize navbar transitions

### DIFF
--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -12,6 +12,14 @@
     transition-timing-function: ease-in-out;
 }
 
+.navbar[data-slide='up'] {
+    transform: translateY(-100%);
+}
+
+.navbar[data-slide='down'] {
+    transform: translateY(0%);
+}
+
 .navbar[data-theme='inverse'] {
     background-color: var(--clr-neutral-100);
     color: var(--clr-primary-400);
@@ -24,9 +32,21 @@
     align-items: center;
 }
 
+.navbar__brand {
+    opacity: 0;
+    transition: opacity 500ms ease-in;
+}
+
+.navbar__brand[data-show='true'] {
+    opacity: 1;
+}
+
+.navbar__brand[data-show='false'] {
+    opacity: 0;
+}
+
 .navbar__brand img{
-    display: none;
-    width: 5.7rem;
+    width: 5.7em;
 }
 
 .navbar__mobile-menu-toggle {
@@ -41,6 +61,7 @@
 .navbar__links li {
     padding-block: var(--size-15);
     cursor: pointer;
+    transition: color 300ms ease-in;
 }
 
 .navbar__links li.active {
@@ -75,10 +96,13 @@
         padding-block: 0;
     }
 
-    .navbar__brand img{
-        display: block;
-        width: 4.125rem;
+    .navbar__brand {
+        opacity: 1;
         padding-block: var(--size-75);
+    }
+
+    .navbar__brand img {
+        width: 4.125em;
     }
 
     .navbar__container {

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Navbar from '../components/Navbar/Navbar';
 import HomeBanner from '../components/HomeBanner/HomeBanner';
 import AboutUs from '../components/AboutUs/AboutUs';
@@ -6,39 +6,57 @@ import Services from '../components/Services/Services';
 
 const useHomeBannerOnScreen = (options) => {
     const homeRef = useRef(null);
+    const [orientationChange, setOrientationChange] = useState(0);
 
     useEffect(() => {
         const navbar = document.querySelector('.navbar');
+        const brand = navbar.querySelector('.navbar__brand');
         const currentRef = homeRef.current;
         let lastScrollTop;
+        const screenOrientation = window.screen.orientation;
         const scrollCallback = ()  => {
             const currentScrollTop = window.pageYOffset || document.documentElement.scrollTop;
             if(currentScrollTop > lastScrollTop) {
-                navbar.style.transform = 'translateY(-100%)';
+                navbar.setAttribute('data-slide','up');
             } else {
-                navbar.style.transform = 'translateY(0%)';
+                navbar.setAttribute('data-slide','down');
             }
             lastScrollTop = currentScrollTop;
         }
+        const orientationCallback = () => {
+            setOrientationChange(orientationChange + 1);
+        }
         const observerCallback = ([entry]) => {
             if(entry.isIntersecting) {
+                if (window.innerWidth >= 1008) {
+                    brand.setAttribute('data-show','false');
+                } else {
+                    brand.setAttribute('data-show','true');
+                }
                 navbar.removeAttribute('data-theme');
-                navbar.style.transform = 'translateY(0%)';
+                navbar.setAttribute('data-slide','down');
                 document.removeEventListener('scroll', scrollCallback);
             } else {
-                navbar.setAttribute('data-theme', 'inverse');
-                document.addEventListener('scroll', scrollCallback)
+                if (window.innerWidth >= 1008) {
+                    navbar.setAttribute('data-theme', 'inverse');
+                    brand.setAttribute('data-show','true');
+                    document.addEventListener('scroll', scrollCallback);
+                } else {
+                    brand.setAttribute('data-show','true');
+                }
             }
         }
 
         const observer = new IntersectionObserver(observerCallback, options);
         if(currentRef) observer.observe(currentRef);
-
+        screenOrientation.addEventListener('change', orientationCallback);
+        
         return () => {
             if(currentRef) observer.unobserve(currentRef);
             document.removeEventListener('scroll', scrollCallback);
+            screenOrientation.removeEventListener('change', orientationCallback);
         }
-    }, [homeRef, options])
+    }, [homeRef, orientationChange])
 
     return [homeRef];
 }

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,7 @@
     --clr-primary-400: hsl(212, 47%, 38%);
 
     --clr-accent-100: hsl(212, 0%, 80%);
-    --clr-accent-200: hsl(212, 0%, 58%);
+    --clr-accent-200: hsl(212, 0%, 55%);
     --clr-accent-400: hsl(212, 30%, 50%);
     --clr-accent-800: hsl(212, 70%, 10%);
 


### PR DESCRIPTION
Add brand image show/hide on scroll pass home section on large screen sizes.
Disable navbar and brand image show/hide on mobile screen sizes, unless it is more than 1008px wide.
Intersection observer custom hook re-run when screen orientation changes to ensure navbar functionality as intended.